### PR TITLE
Fix sqlite example env

### DIFF
--- a/v3-sql-v4-sql/.env.sqlite.example
+++ b/v3-sql-v4-sql/.env.sqlite.example
@@ -6,4 +6,4 @@ BATCH_SIZE=50
 DATABASE_V3_PATH=/exact/path/to/your/v3/data.db
 
 # V4 Settings
-DATABASE_V4_URL=/exact/path/to/your/v4/data.db
+DATABASE_V4_PATH=/exact/path/to/your/v4/data.db


### PR DESCRIPTION
The v4 env var uses the wrong name for v4.