### PR TITLE
fix: missing camelCase for edit rows in layouts

### DIFF
--- a/v3-sql-v4-sql/migrate/migrateCoreStore.js
+++ b/v3-sql-v4-sql/migrate/migrateCoreStore.js
@@ -50,6 +50,9 @@ async function migrateTables() {
 
       if (value.layouts) {
         value.layouts.list = value.layouts.list.map((item) => camelCase(item));
+        value.layouts.edit = value.layouts.edit.map((row) =>
+          row.map((column) => ({ ...column, name: camelCase(column.name) }))
+        );
       }
 
       const valueToSave = value.metadatas


### PR DESCRIPTION
Add camelCase conversion in migrateCoreStore for edit layout. Since in DB is all this saved as camelCase, it needs to be converted. If not strapi create new field in core store and doubles it in view.

Fixes #17 