### PR TITLE
Fix: Do not omit "created_at" and "updated_at" fields during migration

### DIFF
--- a/v3-sql-v4-sql/migrate/migrateModels.js
+++ b/v3-sql-v4-sql/migrate/migrateModels.js
@@ -56,9 +56,11 @@ async function migrateModels(tables) {
           updated_at: item[updatedAt],
         };
 
-        return migrateItem(
-          omit(newItem, [...omitAttributes, createdAt, updatedAt])
-        );
+        let omitFields = [...omitAttributes];
+        if(createdAt != "created_at") omitFields.push(createdAt);
+        if(updatedAt != "updated_at") omitFields.push(updatedAt);
+
+        return migrateItem(omit(newItem, omitFields));
       }
     });
   }


### PR DESCRIPTION
If "created_at" and/or "updated_at" timestamps fields are already used by the source model do not omit them during migration ->  Only omit timestamp fields with different names. 

I guess the whole method would profit from further refactoring, e.g. by simplifying its conditions/cases.
Since I am lacking deeper knowledge of older strapi versions and possible outcomes I focused on fixing the bug.

fixes #21 