### PR TITLE
fixes finding of v4 db tables as part of relations migration for mysql databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ dist
 data.db
 
 # End of https://www.toptal.com/developers/gitignore/api/node
+
+# IDE config
+.idea

--- a/v3-sql-v4-sql/migrate/helpers/relationHelpers.js
+++ b/v3-sql-v4-sql/migrate/helpers/relationHelpers.js
@@ -158,7 +158,7 @@ async function migrateRelations(tables, relations) {
 
   if (isMYSQL) {
     v4Tables = (
-      await dbV3("information_schema.tables").select("table_name")
+      await dbV4("information_schema.tables").select("table_name")
     ).map((row) => row.table_name);
   }
 


### PR DESCRIPTION
There is a bug in the relationsHelpers.js file where for MySQL databases the code points to the v3 db config when fetching all the v4 db tables. This prevents relations from being included in the data migration for projects using a MySQL db. This PR fixes this bug.