### PR TITLE
FIX: related_<entity>_id in table <entity>_localization_links

### DIFF
--- a/v3-sql-v4-sql/migrate/helpers/migrate.js
+++ b/v3-sql-v4-sql/migrate/helpers/migrate.js
@@ -129,6 +129,17 @@ async function migrate(source, destination, itemMapper = undefined) {
 
     const migratedItems = migrateItems(withParsedJsonFields, itemMapper).map(
       (item) => {
+
+        if (source.match(/\w*(?=__localizations)/) && destination.match(/\w*(?=_localizations_links)/)) {
+          for (var key in item) {
+            let match = key.match(/(?<=related_)\w*/)
+            if (match) {
+              Object.defineProperty(item, `inv_${match}`, Object.getOwnPropertyDescriptor(item, key));
+              delete item[key];
+            }
+          }
+        }
+
         const filteredItems = pick(item, tableColumns);
 
         if (Object.keys(item).length !== Object.keys(filteredItems).length) {


### PR DESCRIPTION
During migration from v3 to v4, some tables named entity.localization_links had an empty column : inv_entity_id.

I found out that tables using i18n plugin change their name from entities__localizations to entities_localizations_links and also their column related_entity_id became inv_entity_id. (https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/data/sql.html#internationalization-i18n-plugin)

In migration-script, I think this modification is not supported, so I implement it and I created this PR.

What this PR does : 
 - On tables using localizations, modify locally the name of related_entity_id to inv_entity_id, so script can copy data from old table in it.

PS: (This is my first PR to open-source project, therefore if I did something wrong in it, do not hesitate to give your feedback)