### PR TITLE
sql migration: fixed table names, better sql and singular api names.

### DIFF
--- a/v3-sql-v4-sql/migrate/helpers/migrate.js
+++ b/v3-sql-v4-sql/migrate/helpers/migrate.js
@@ -162,7 +162,7 @@ async function resetTableSequence(destination) {
     if (hasId) {
       const seq = `${destination.slice(0, 56)}_id_seq`;
       await dbV4.raw(
-        `SELECT SETVAL ('${seq}', (SELECT MAX(id) + 1 FROM "${destination}""))`
+        `SELECT SETVAL ('${seq}', (SELECT MAX(id) + 1 FROM "${destination}"))`
       );
     }
   }

--- a/v3-sql-v4-sql/migrate/helpers/migrate.js
+++ b/v3-sql-v4-sql/migrate/helpers/migrate.js
@@ -1,18 +1,11 @@
-const {
-  dbV3,
-  dbV4,
-  isPGSQL,
-  isMYSQL,
-  isSQLITE,
-} = require("../../config/database");
-const { BATCH_SIZE } = require("./constants");
-const { migrateItems } = require("./migrateFields");
-const { pick } = require("lodash");
+const { dbV3, dbV4, isPGSQL, isMYSQL, isSQLITE } = require('../../config/database');
+const { BATCH_SIZE } = require('./constants');
+const { migrateItems } = require('./migrateFields');
+const { pick } = require('lodash');
 
 async function migrate(source, destination, itemMapper = undefined) {
   if (isMYSQL) {
-    const sourceNotExists =
-      (await dbV3.raw(`SHOW TABLES LIKE '%${source}%';`))[0].length === 0;
+    const sourceNotExists = (await dbV3.raw(`SHOW TABLES LIKE '%${source}%';`))[0].length === 0;
     const destinationNotExists =
       (await dbV4.raw(`SHOW TABLES LIKE '%${destination}%';`))[0].length === 0;
 
@@ -32,23 +25,23 @@ async function migrate(source, destination, itemMapper = undefined) {
 
     const sourceNotExists =
       (
-        await dbV3("sqlite_master")
-          .select("name")
-          .where("type", "table")
-          .where("name", source)
+        await dbV3('sqlite_master')
+          .select('name')
+          .where('type', 'table')
+          .where('name', source)
           .first()
           .count()
-      )["count(*)"] === 0;
+      )['count(*)'] === 0;
 
     const destinationNotExists =
       (
-        await dbV4("sqlite_master")
-          .select("name")
-          .where("type", "table")
-          .where("name", destination)
+        await dbV4('sqlite_master')
+          .select('name')
+          .where('type', 'table')
+          .where('name', destination)
           .first()
           .count()
-      )["count(*)"] === 0;
+      )['count(*)'] === 0;
 
     if (sourceNotExists) {
       console.log(`SOURCE TABLE ${source} DOES NOT EXISTS`);
@@ -68,18 +61,18 @@ async function migrate(source, destination, itemMapper = undefined) {
 
     const sourceNotExists =
       (
-        await dbV3("information_schema.tables")
-          .select("table_name")
-          .where("table_schema", "public")
-          .where("table_name", source)
+        await dbV3('information_schema.tables')
+          .select('table_name')
+          .where('table_schema', 'public')
+          .where('table_name', source)
       ).length === 0;
 
     const destinationNotExists =
       (
-        await dbV4("information_schema.tables")
-          .select("table_name")
-          .where("table_schema", "public")
-          .where("table_name", destination)
+        await dbV4('information_schema.tables')
+          .select('table_name')
+          .where('table_schema', 'public')
+          .where('table_name', destination)
       ).length === 0;
 
     if (sourceNotExists) {
@@ -94,18 +87,17 @@ async function migrate(source, destination, itemMapper = undefined) {
   }
 
   const count =
-    (await dbV3(source).count().first()).count ||
-    (await dbV3(source).count().first())["count(*)"];
+    (await dbV3(source).count().first()).count || (await dbV3(source).count().first())['count(*)'];
   const columnsInfo = await dbV3(source).columnInfo();
 
   const jsonFields = Object.keys(columnsInfo).filter((column) => {
-    return columnsInfo[column].type === "jsonb";
+    return columnsInfo[column].type === 'jsonb';
   });
 
   console.log(`Migrating ${count} items from ${source} to ${destination}`);
   await dbV4(destination).del();
 
-  console.log("DBV4 ITEMS");
+  console.log('DBV4 ITEMS');
 
   const tableColumnsInfo = await dbV4(destination).columnInfo();
 
@@ -127,26 +119,21 @@ async function migrate(source, destination, itemMapper = undefined) {
       return item;
     });
 
-    const migratedItems = migrateItems(withParsedJsonFields, itemMapper).map(
-      (item) => {
-        const filteredItems = pick(item, tableColumns);
+    const migratedItems = migrateItems(withParsedJsonFields, itemMapper).map((item) => {
+      const filteredItems = pick(item, tableColumns);
 
-        if (Object.keys(item).length !== Object.keys(filteredItems).length) {
-          const filteredColumns = Object.keys(item).filter(function (obj) {
-            return Object.keys(filteredItems).indexOf(obj) == -1;
-          });
+      if (Object.keys(item).length !== Object.keys(filteredItems).length) {
+        const filteredColumns = Object.keys(item).filter(function (obj) {
+          return Object.keys(filteredItems).indexOf(obj) == -1;
+        });
 
-          console.log(
-            "WARNING - items of " +
-              destination +
-              " was filtered " +
-              JSON.stringify(filteredColumns)
-          );
-        }
-
-        return filteredItems;
+        console.log(
+          'WARNING - items of ' + destination + ' was filtered ' + JSON.stringify(filteredColumns)
+        );
       }
-    );
+
+      return filteredItems;
+    });
 
     if (migratedItems.length > 0) {
       await dbV4(destination).insert(migratedItems);
@@ -158,12 +145,10 @@ async function migrate(source, destination, itemMapper = undefined) {
 
 async function resetTableSequence(destination) {
   if (isPGSQL) {
-    const hasId = await dbV4.schema.hasColumn(destination, "id");
+    const hasId = await dbV4.schema.hasColumn(destination, 'id');
     if (hasId) {
       const seq = `${destination.slice(0, 56)}_id_seq`;
-      await dbV4.raw(
-        `SELECT SETVAL ('${seq}', (SELECT MAX(id) + 1 FROM ${destination}))`
-      );
+      await dbV4.raw(`SELECT SETVAL ('${seq}', (SELECT MAX(id) + 1 FROM "${destination}"))`);
     }
   }
 }

--- a/v3-sql-v4-sql/migrate/helpers/migrate.js
+++ b/v3-sql-v4-sql/migrate/helpers/migrate.js
@@ -1,11 +1,18 @@
-const { dbV3, dbV4, isPGSQL, isMYSQL, isSQLITE } = require('../../config/database');
-const { BATCH_SIZE } = require('./constants');
-const { migrateItems } = require('./migrateFields');
-const { pick } = require('lodash');
+const {
+  dbV3,
+  dbV4,
+  isPGSQL,
+  isMYSQL,
+  isSQLITE,
+} = require("../../config/database");
+const { BATCH_SIZE } = require("./constants");
+const { migrateItems } = require("./migrateFields");
+const { pick } = require("lodash");
 
 async function migrate(source, destination, itemMapper = undefined) {
   if (isMYSQL) {
-    const sourceNotExists = (await dbV3.raw(`SHOW TABLES LIKE '%${source}%';`))[0].length === 0;
+    const sourceNotExists =
+      (await dbV3.raw(`SHOW TABLES LIKE '%${source}%';`))[0].length === 0;
     const destinationNotExists =
       (await dbV4.raw(`SHOW TABLES LIKE '%${destination}%';`))[0].length === 0;
 
@@ -25,23 +32,23 @@ async function migrate(source, destination, itemMapper = undefined) {
 
     const sourceNotExists =
       (
-        await dbV3('sqlite_master')
-          .select('name')
-          .where('type', 'table')
-          .where('name', source)
+        await dbV3("sqlite_master")
+          .select("name")
+          .where("type", "table")
+          .where("name", source)
           .first()
           .count()
-      )['count(*)'] === 0;
+      )["count(*)"] === 0;
 
     const destinationNotExists =
       (
-        await dbV4('sqlite_master')
-          .select('name')
-          .where('type', 'table')
-          .where('name', destination)
+        await dbV4("sqlite_master")
+          .select("name")
+          .where("type", "table")
+          .where("name", destination)
           .first()
           .count()
-      )['count(*)'] === 0;
+      )["count(*)"] === 0;
 
     if (sourceNotExists) {
       console.log(`SOURCE TABLE ${source} DOES NOT EXISTS`);
@@ -61,18 +68,18 @@ async function migrate(source, destination, itemMapper = undefined) {
 
     const sourceNotExists =
       (
-        await dbV3('information_schema.tables')
-          .select('table_name')
-          .where('table_schema', 'public')
-          .where('table_name', source)
+        await dbV3("information_schema.tables")
+          .select("table_name")
+          .where("table_schema", "public")
+          .where("table_name", source)
       ).length === 0;
 
     const destinationNotExists =
       (
-        await dbV4('information_schema.tables')
-          .select('table_name')
-          .where('table_schema', 'public')
-          .where('table_name', destination)
+        await dbV4("information_schema.tables")
+          .select("table_name")
+          .where("table_schema", "public")
+          .where("table_name", destination)
       ).length === 0;
 
     if (sourceNotExists) {
@@ -87,17 +94,18 @@ async function migrate(source, destination, itemMapper = undefined) {
   }
 
   const count =
-    (await dbV3(source).count().first()).count || (await dbV3(source).count().first())['count(*)'];
+    (await dbV3(source).count().first()).count ||
+    (await dbV3(source).count().first())["count(*)"];
   const columnsInfo = await dbV3(source).columnInfo();
 
   const jsonFields = Object.keys(columnsInfo).filter((column) => {
-    return columnsInfo[column].type === 'jsonb';
+    return columnsInfo[column].type === "jsonb";
   });
 
   console.log(`Migrating ${count} items from ${source} to ${destination}`);
   await dbV4(destination).del();
 
-  console.log('DBV4 ITEMS');
+  console.log("DBV4 ITEMS");
 
   const tableColumnsInfo = await dbV4(destination).columnInfo();
 
@@ -119,21 +127,26 @@ async function migrate(source, destination, itemMapper = undefined) {
       return item;
     });
 
-    const migratedItems = migrateItems(withParsedJsonFields, itemMapper).map((item) => {
-      const filteredItems = pick(item, tableColumns);
+    const migratedItems = migrateItems(withParsedJsonFields, itemMapper).map(
+      (item) => {
+        const filteredItems = pick(item, tableColumns);
 
-      if (Object.keys(item).length !== Object.keys(filteredItems).length) {
-        const filteredColumns = Object.keys(item).filter(function (obj) {
-          return Object.keys(filteredItems).indexOf(obj) == -1;
-        });
+        if (Object.keys(item).length !== Object.keys(filteredItems).length) {
+          const filteredColumns = Object.keys(item).filter(function (obj) {
+            return Object.keys(filteredItems).indexOf(obj) == -1;
+          });
 
-        console.log(
-          'WARNING - items of ' + destination + ' was filtered ' + JSON.stringify(filteredColumns)
-        );
+          console.log(
+            "WARNING - items of " +
+              destination +
+              " was filtered " +
+              JSON.stringify(filteredColumns)
+          );
+        }
+
+        return filteredItems;
       }
-
-      return filteredItems;
-    });
+    );
 
     if (migratedItems.length > 0) {
       await dbV4(destination).insert(migratedItems);
@@ -145,10 +158,12 @@ async function migrate(source, destination, itemMapper = undefined) {
 
 async function resetTableSequence(destination) {
   if (isPGSQL) {
-    const hasId = await dbV4.schema.hasColumn(destination, 'id');
+    const hasId = await dbV4.schema.hasColumn(destination, "id");
     if (hasId) {
       const seq = `${destination.slice(0, 56)}_id_seq`;
-      await dbV4.raw(`SELECT SETVAL ('${seq}', (SELECT MAX(id) + 1 FROM "${destination}"))`);
+      await dbV4.raw(
+        `SELECT SETVAL ('${seq}', (SELECT MAX(id) + 1 FROM "${destination}""))`
+      );
     }
   }
 }

--- a/v3-sql-v4-sql/migrate/helpers/migrateValues.js
+++ b/v3-sql-v4-sql/migrate/helpers/migrateValues.js
@@ -1,26 +1,36 @@
-const { cloneDeepWith, camelCase, isObject, isString } = require("lodash");
+const { cloneDeepWith, camelCase, isObject, isString } = require('lodash');
+const _ = require('lodash');
+const pluralize = require('pluralize');
 
 function migrateUids(uid) {
   if (!uid) {
     return uid;
   }
   var result = uid;
-  result = result.replace("strapi::", "admin::");
-  result = result.replace("application::", "api::");
-  result = result.replace(
-    "plugins::users-permission",
-    "plugin::users-permissions"
-  );
-  result = result.replace("plugins::", "plugin::");
+  result = result.replace('strapi::', 'admin::');
+  result = result.replace('application::', 'api::');
+  result = result.replace('plugins::users-permission', 'plugin::users-permissions');
+  result = result.replace('plugins::', 'plugin::');
+
+  //for "api::pluralname.pluralname" uids, apply same pluralize.singular function as codemods does in https://github.com/strapi/codemods/blob/5673120b8b3d4920d9d835776ee0308196b10628/lib/v4/migration-helpers/get-relation-object.js
+  if (result.substring(0, 5) == 'api::') {
+    const arrParts = result.substring(5).split('.');
+    if (arrParts.length == 2) {
+      result = `api::${_.kebabCase(pluralize.singular(arrParts[0]))}.${_.kebabCase(
+        pluralize.singular(arrParts[1])
+      )}`;
+    }
+  }
+
   return result;
 }
 
 function migrateItemValues(item) {
   return cloneDeepWith(item, (value, key) => {
-    if (key === "label" && !isObject(value)) {
+    if (key === 'label' && !isObject(value)) {
       return camelCase(value);
     }
-    if (key === "uid" && !isObject(value)) {
+    if (key === 'uid' && !isObject(value)) {
       return migrateUids(value);
     }
   });

--- a/v3-sql-v4-sql/migrate/helpers/migrateValues.js
+++ b/v3-sql-v4-sql/migrate/helpers/migrateValues.js
@@ -1,4 +1,4 @@
-const { cloneDeepWith, camelCase, isObject, isString } = require('lodash');
+const { cloneDeepWith, camelCase, isObject, isString } = require("lodash");
 const _ = require('lodash');
 const pluralize = require('pluralize');
 
@@ -7,10 +7,13 @@ function migrateUids(uid) {
     return uid;
   }
   var result = uid;
-  result = result.replace('strapi::', 'admin::');
-  result = result.replace('application::', 'api::');
-  result = result.replace('plugins::users-permission', 'plugin::users-permissions');
-  result = result.replace('plugins::', 'plugin::');
+  result = result.replace("strapi::", "admin::");
+  result = result.replace("application::", "api::");
+  result = result.replace(
+    "plugins::users-permission",
+    "plugin::users-permissions"
+  );
+  result = result.replace("plugins::", "plugin::");
 
   //for "api::pluralname.pluralname" uids, apply same pluralize.singular function as codemods does in https://github.com/strapi/codemods/blob/5673120b8b3d4920d9d835776ee0308196b10628/lib/v4/migration-helpers/get-relation-object.js
   if (result.substring(0, 5) == 'api::') {
@@ -21,16 +24,16 @@ function migrateUids(uid) {
       )}`;
     }
   }
-
+  
   return result;
 }
 
 function migrateItemValues(item) {
   return cloneDeepWith(item, (value, key) => {
-    if (key === 'label' && !isObject(value)) {
+    if (key === "label" && !isObject(value)) {
       return camelCase(value);
     }
-    if (key === 'uid' && !isObject(value)) {
+    if (key === "uid" && !isObject(value)) {
       return migrateUids(value);
     }
   });

--- a/v3-sql-v4-sql/migrate/migrateFiles.js
+++ b/v3-sql-v4-sql/migrate/migrateFiles.js
@@ -1,17 +1,21 @@
-const { migrate } = require('./helpers/migrate');
-const { omit } = require('lodash');
-const { snakeCase } = require('lodash/fp');
-const { dbV3 } = require('../config/database');
-const { migrateUids } = require('./helpers/migrateValues');
+const { migrate } = require("./helpers/migrate");
+const { omit } = require("lodash");
+const { snakeCase } = require("lodash/fp");
+const { dbV3 } = require("../config/database");
+const { migrateUids } = require("./helpers/migrateValues");
 
-const processedTables = ['upload_file', 'upload_file_morph'];
-const newTables = ['files', 'files_related_morphs'];
+const processedTables = ["upload_file", "upload_file_morph"];
+const newTables = ["files", "files_related_morphs"];
 
 async function migrateTables() {
   // TODO have to migrate values
-  console.log('Migrating files');
+  console.log("Migrating files");
 
-  const modelsDefs = await dbV3('core_store').where('key', 'like', 'model_def_%');
+  const modelsDefs = await dbV3("core_store").where(
+    "key",
+    "like",
+    "model_def_%"
+  );
 
   const componentsMap = modelsDefs
     .map((item) => JSON.parse(item.value))
@@ -38,7 +42,7 @@ async function migrateTables() {
       updated_by_id: item.updated_by,
     };
 
-    return omit(newItem, ['created_by', 'updated_by']);
+    return omit(newItem, ["created_by", "updated_by"]);
   });
 
   await migrate(processedTables[1], newTables[1], (item) => {
@@ -48,7 +52,7 @@ async function migrateTables() {
       related_type: componentsMap[item.related_type] || related_type,
     };
 
-    return omit(newItem, ['upload_file_id', 'id']);
+    return omit(newItem, ["upload_file_id", "id"]);
   });
 }
 

--- a/v3-sql-v4-sql/migrate/migrateFiles.js
+++ b/v3-sql-v4-sql/migrate/migrateFiles.js
@@ -1,21 +1,17 @@
-const { migrate } = require("./helpers/migrate");
-const { omit } = require("lodash");
-const { snakeCase } = require("lodash/fp");
-const { dbV3 } = require("../config/database");
-const { migrateUids } = require("./helpers/migrateValues");
+const { migrate } = require('./helpers/migrate');
+const { omit } = require('lodash');
+const { snakeCase } = require('lodash/fp');
+const { dbV3 } = require('../config/database');
+const { migrateUids } = require('./helpers/migrateValues');
 
-const processedTables = ["upload_file", "upload_file_morph"];
-const newTables = ["files", "files_related_morphs"];
+const processedTables = ['upload_file', 'upload_file_morph'];
+const newTables = ['files', 'files_related_morphs'];
 
 async function migrateTables() {
   // TODO have to migrate values
-  console.log("Migrating files");
+  console.log('Migrating files');
 
-  const modelsDefs = await dbV3("core_store").where(
-    "key",
-    "like",
-    "model_def_%"
-  );
+  const modelsDefs = await dbV3('core_store').where('key', 'like', 'model_def_%');
 
   const componentsMap = modelsDefs
     .map((item) => JSON.parse(item.value))
@@ -42,7 +38,7 @@ async function migrateTables() {
       updated_by_id: item.updated_by,
     };
 
-    return omit(newItem, ["created_by", "updated_by"]);
+    return omit(newItem, ['created_by', 'updated_by']);
   });
 
   await migrate(processedTables[1], newTables[1], (item) => {
@@ -52,7 +48,7 @@ async function migrateTables() {
       related_type: componentsMap[item.related_type] || related_type,
     };
 
-    return omit(newItem, ["upload_file_id", "id"]);
+    return omit(newItem, ['upload_file_id', 'id']);
   });
 }
 

--- a/v3-sql-v4-sql/migrate/migrateUsers.js
+++ b/v3-sql-v4-sql/migrate/migrateUsers.js
@@ -1,31 +1,28 @@
-const { dbV3, dbV4 } = require("../config/database");
-const { BATCH_SIZE } = require("./helpers/constants");
-const { migrate, resetTableSequence } = require("./helpers/migrate");
-const { migrateItems, migrateItem } = require("./helpers/migrateFields");
-const { migrateUserPermissionAction } = require("./helpers/usersHelpers");
+const { dbV3, dbV4 } = require('../config/database');
+const { BATCH_SIZE } = require('./helpers/constants');
+const { migrate, resetTableSequence } = require('./helpers/migrate');
+const { migrateItems, migrateItem } = require('./helpers/migrateFields');
+const { migrateUserPermissionAction } = require('./helpers/usersHelpers');
 
 const processedTables = [
-  "users-permissions_role",
-  "users-permissions_permission",
-  "users-permissions_user",
+  'users-permissions_role',
+  'users-permissions_permission',
+  'users-permissions_user',
 ];
 
 async function migrateUserPermissions() {
-  const source = "users-permissions_permission";
-  const destination = "up_permissions";
-  const destinationLinks = "up_permissions_role_links";
+  const source = 'users-permissions_permission';
+  const destination = 'up_permissions';
+  const destinationLinks = 'up_permissions_role_links';
 
-  const sourceSelect = dbV3(source).where("enabled", true);
+  const sourceSelect = dbV3(source).where('enabled', true);
   const count =
     (await sourceSelect.clone().count().first()).count ||
-    (await sourceSelect.clone().count().first())["count(*)"];
+    (await sourceSelect.clone().count().first())['count(*)'];
   const countTotal =
-    (await dbV3(source).count().first()).count ||
-    (await dbV3(source).count().first())["count(*)"];
+    (await dbV3(source).count().first()).count || (await dbV3(source).count().first())['count(*)'];
 
-  console.log(
-    `Migrating ${count}/${countTotal} items from ${source} to ${destination}`
-  );
+  console.log(`Migrating ${count}/${countTotal} items from ${source} to ${destination}`);
   await dbV4(destinationLinks).del();
   await dbV4(destination).del();
   for (var page = 0; page * BATCH_SIZE < count; page++) {
@@ -53,13 +50,13 @@ async function migrateUserPermissions() {
 }
 
 async function migrateUsersData() {
-  const source = "users-permissions_user";
-  const destination = "up_users";
-  const destinationLinks = "up_users_role_links";
+  const source = 'users-permissions_user';
+  const destination = 'users-permissions_user';
+  const destinationLinks = 'users_permissions_user_role_links';
 
   const count =
     (await dbV3(source).count().first()).count ||
-    (await dbV3(source).clone().count().first())["count(*)"];
+    (await dbV3(source).clone().count().first())['count(*)'];
   console.log(`Migrating ${count} items from ${source} to ${destination}`);
   await dbV4(destinationLinks).del();
   await dbV4(destination).del();
@@ -68,9 +65,7 @@ async function migrateUsersData() {
     const items = await dbV3(source)
       .limit(BATCH_SIZE)
       .offset(page * BATCH_SIZE);
-    const migratedItems = migrateItems(items, ({ role, ...item }) =>
-      migrateItem(item)
-    );
+    const migratedItems = migrateItems(items, ({ role, ...item }) => migrateItem(item));
     const roleLinks = items.map((item) => ({
       user_id: item.id,
       role_id: item.role,
@@ -82,8 +77,8 @@ async function migrateUsersData() {
 }
 
 async function migrateTables() {
-  console.log("Migrating Users");
-  await migrate("users-permissions_role", "up_roles");
+  console.log('Migrating Users');
+  await migrate('users-permissions_role', 'up_roles');
   await migrateUserPermissions();
   await migrateUsersData();
 }

--- a/v3-sql-v4-sql/migrate/migrateUsers.js
+++ b/v3-sql-v4-sql/migrate/migrateUsers.js
@@ -1,28 +1,31 @@
-const { dbV3, dbV4 } = require('../config/database');
-const { BATCH_SIZE } = require('./helpers/constants');
-const { migrate, resetTableSequence } = require('./helpers/migrate');
-const { migrateItems, migrateItem } = require('./helpers/migrateFields');
-const { migrateUserPermissionAction } = require('./helpers/usersHelpers');
+const { dbV3, dbV4 } = require("../config/database");
+const { BATCH_SIZE } = require("./helpers/constants");
+const { migrate, resetTableSequence } = require("./helpers/migrate");
+const { migrateItems, migrateItem } = require("./helpers/migrateFields");
+const { migrateUserPermissionAction } = require("./helpers/usersHelpers");
 
 const processedTables = [
-  'users-permissions_role',
-  'users-permissions_permission',
-  'users-permissions_user',
+  "users-permissions_role",
+  "users-permissions_permission",
+  "users-permissions_user",
 ];
 
 async function migrateUserPermissions() {
-  const source = 'users-permissions_permission';
-  const destination = 'up_permissions';
-  const destinationLinks = 'up_permissions_role_links';
+  const source = "users-permissions_permission";
+  const destination = "up_permissions";
+  const destinationLinks = "up_permissions_role_links";
 
-  const sourceSelect = dbV3(source).where('enabled', true);
+  const sourceSelect = dbV3(source).where("enabled", true);
   const count =
     (await sourceSelect.clone().count().first()).count ||
-    (await sourceSelect.clone().count().first())['count(*)'];
+    (await sourceSelect.clone().count().first())["count(*)"];
   const countTotal =
-    (await dbV3(source).count().first()).count || (await dbV3(source).count().first())['count(*)'];
+    (await dbV3(source).count().first()).count ||
+    (await dbV3(source).count().first())["count(*)"];
 
-  console.log(`Migrating ${count}/${countTotal} items from ${source} to ${destination}`);
+  console.log(
+    `Migrating ${count}/${countTotal} items from ${source} to ${destination}`
+  );
   await dbV4(destinationLinks).del();
   await dbV4(destination).del();
   for (var page = 0; page * BATCH_SIZE < count; page++) {
@@ -50,13 +53,13 @@ async function migrateUserPermissions() {
 }
 
 async function migrateUsersData() {
-  const source = 'users-permissions_user';
-  const destination = 'users-permissions_user';
-  const destinationLinks = 'users_permissions_user_role_links';
+  const source = "users-permissions_user";
+  const destination = "users-permissions_user";
+  const destinationLinks = "users_permissions_user_role_links";
 
   const count =
     (await dbV3(source).count().first()).count ||
-    (await dbV3(source).clone().count().first())['count(*)'];
+    (await dbV3(source).clone().count().first())["count(*)"];
   console.log(`Migrating ${count} items from ${source} to ${destination}`);
   await dbV4(destinationLinks).del();
   await dbV4(destination).del();
@@ -65,7 +68,9 @@ async function migrateUsersData() {
     const items = await dbV3(source)
       .limit(BATCH_SIZE)
       .offset(page * BATCH_SIZE);
-    const migratedItems = migrateItems(items, ({ role, ...item }) => migrateItem(item));
+    const migratedItems = migrateItems(items, ({ role, ...item }) =>
+      migrateItem(item)
+    );
     const roleLinks = items.map((item) => ({
       user_id: item.id,
       role_id: item.role,
@@ -77,8 +82,8 @@ async function migrateUsersData() {
 }
 
 async function migrateTables() {
-  console.log('Migrating Users');
-  await migrate('users-permissions_role', 'up_roles');
+  console.log("Migrating Users");
+  await migrate("users-permissions_role", "up_roles");
   await migrateUserPermissions();
   await migrateUsersData();
 }


### PR DESCRIPTION
Hi,
I'm working on migrating a strapi project (on postgres) from v3 to v4.
After using [codemods](https://github.com/strapi/codemods/) succesfully to migrate the code, I had to change some things in the migration scripts:
1- User tables had different names (I couldn't find any references to the current names. maybe in earlier versions?)
2- In a SQL query, I added double quotes around the table name so it supports names with `-`.
3- I applied `pluralize.singular` for uids like `api::pluralname.pluralname` in the same way codemods does. Now the field `related_type` on table `files_related_morphs` gets migrated correctly and I don't lose the relation to media uploads.

Number 3 is probably necessary only if the code was migrated using codemods, so maybe the script needs to check that somehow.
Let me know if you need any extra info.