### PR TITLE
Fix migrateField mapping for i18n related_/inv column

### DIFF
--- a/v3-sql-v4-sql/migrate/helpers/migrateFields.js
+++ b/v3-sql-v4-sql/migrate/helpers/migrateFields.js
@@ -7,7 +7,7 @@ function migrateField(fieldName) {
     case "updated_by":
       return "updated_by_id";
     default:
-      return snakeCase(fieldName);
+      return snakeCase(fieldName).replace(/^related_(.*)?$/, 'inv_$1');
   }
 }
 


### PR DESCRIPTION
This PR is in favor of the existing PR that has introduced more logic, whilst this PR focusses on the mapping in the migrateField helper function.