### PR TITLE
Fix non-escaped destination in sequence reset

### DIFF
--- a/v3-sql-v4-sql/migrate/helpers/migrate.js
+++ b/v3-sql-v4-sql/migrate/helpers/migrate.js
@@ -162,7 +162,7 @@ async function resetTableSequence(destination) {
     if (hasId) {
       const seq = `${destination.slice(0, 56)}_id_seq`;
       await dbV4.raw(
-        `SELECT SETVAL ('${seq}', (SELECT MAX(id) + 1 FROM ${destination}))`
+        `SELECT SETVAL ('${seq}', (SELECT MAX(id) + 1 FROM '${destination}'))`
       );
     }
   }


### PR DESCRIPTION
destination table names were not being escaped and throwing errors if the destination had a `-` in it