### PR TITLE
Fix - Remove uid check from migrate files

### DIFF
--- a/v3-sql-v4-sql/migrate/migrateFiles.js
+++ b/v3-sql-v4-sql/migrate/migrateFiles.js
@@ -31,12 +31,7 @@ async function migrateTables() {
     );
 
   await migrate(processedTables[0], newTables[0], (item) => {
-    const withRenamedKeys = Object.keys(item).reduce((acc, item) => {
-      if (item.uid.startsWith('application::')) {
-        // If v3 uid uses plural collection names this will convert it to singular to match v4
-        const singularUid = singular(item.collectionName);
-        item.uid = `api::${singularUid}.${singularUid}`;
-      }
+    const withRenamedKeys = Object.keys(item).reduce((acc, key) => {
       return {
         ...acc,
         ...{ [snakeCase(key)]: item[key] },


### PR DESCRIPTION
Check is now handled in migrateUid (#56) so this check can be removed. 

Also looks like it got added to the wrong reducer which is causing an error when migrating the files.