### PR TITLE
Correct key when one to one relationship maps to collection with same name

### DIFF
--- a/v3-sql-v4-sql/migrate/helpers/relationHelpers.js
+++ b/v3-sql-v4-sql/migrate/helpers/relationHelpers.js
@@ -76,9 +76,12 @@ function oneToOneRelationMapper(relation, item) {
   const idF = item[relation.attribute];
 
   if (id && idF) {
+    const keyF = relation.entityName === relation.modelF
+      ? `inv_${makeRelationModelId(relation.modelF)}`
+      : makeRelationModelId(relation.modelF);
     return {
       [makeRelationModelId(relation.entityName)]: id,
-      [makeRelationModelId(relation.modelF)]: idF,
+      [keyF]: idF,
     };
   }
   return undefined;


### PR DESCRIPTION
If a component has a one to one relationship with a collection with the same name, Strapi uses the field name `inv_{collectionname}_id` in the links table to distinguish the names.

Fixes #68 