### PR TITLE
Fix a bug where the i18n destination table is not correctly named

### DIFF
--- a/v3-sql-v4-sql/migrate/migrateI18n.js
+++ b/v3-sql-v4-sql/migrate/migrateI18n.js
@@ -4,7 +4,7 @@ async function migrateTables() {
   console.log('Migrate locales (i18n)');
 
   const source = 'i18n_locales';
-  const destination = 'i18n_locale';
+  const destination = 'i18n_locales';
 
   await migrate(source, destination);
 }


### PR DESCRIPTION
The destination table was wrongly named, 
and we had an error when executing the script 
here is a fix 
we used the latest strapi v4 version as migration target