### PR TITLE
Typo fix - moel->model

### DIFF
--- a/v3-mongodb-v3-sql/index.js
+++ b/v3-mongodb-v3-sql/index.js
@@ -226,7 +226,7 @@ async function run() {
 
             const targetAttribute = targetModel?.attributes?.[attribute.via];
 
-            const isOneWay = attribute.model && !attribute.via && attribute.moel !== '*';
+            const isOneWay = attribute.model && !attribute.via && attribute.model !== '*';
             const isOneToOne =
               attribute.model &&
               attribute.via &&

--- a/v3-mongodb-v3-sql/index.js
+++ b/v3-mongodb-v3-sql/index.js
@@ -276,7 +276,7 @@ async function run() {
 
             if (isManyWay) {
               const joinTableName =
-                attribute.collectionName || `${model.collectionName}__${_.snakeCase(key)}`;
+                attribute.collection || `${model.collectionName}__${_.snakeCase(key)}`;
 
               const fk = `${singular(model.collectionName)}_id`;
               let otherFk = `${singular(attribute.collection)}_id`;


### PR DESCRIPTION
## Fixed typo in code - 'moel' 

During determining whether a relationship was 'isOneWay', code checked 'attribute.moel' - typo for 'attribute.model'