### PR TITLE
Apply defaults(if any) if column undefined in mongo + Typo Fix

### DIFF
--- a/v3-mongodb-v3-sql/index.js
+++ b/v3-mongodb-v3-sql/index.js
@@ -226,7 +226,7 @@ async function run() {
 
             const targetAttribute = targetModel?.attributes?.[attribute.via];
 
-            const isOneWay = attribute.model && !attribute.via && attribute.moel !== '*';
+            const isOneWay = attribute.model && !attribute.via && attribute.model !== '*';
             const isOneToOne =
               attribute.model &&
               attribute.via &&

--- a/v3-mongodb-v3-sql/index.js
+++ b/v3-mongodb-v3-sql/index.js
@@ -333,9 +333,8 @@ async function run() {
       }
 
       await cursor.close();
-
-      await dialect.afterMigration?.(knex);
     }
+    await dialect.afterMigration?.(knex);
   } finally {
     await mongo.close();
     await knex.destroy();

--- a/v3-mongodb-v3-sql/transform.js
+++ b/v3-mongodb-v3-sql/transform.js
@@ -36,14 +36,14 @@ function transformEntry(entry, model) {
     res.updated_at = entry[updatedAtKey];
   }
 
-  Object.keys(entry).forEach((key) => {
-    const attribute = model.attributes[key];
-
-    if (!attribute) {
-      return;
-    }
-
+  Object.entries(model.attributes).forEach(([key, attribute]) => {
     if (isScalar(attribute)) {
+      if(!Object.keys(entry).includes(key)) {//handle undefined attribute in entry w/ default value
+        if (attribute.default && attribute.type === 'json') res[key] = JSON.stringify(attribute.default);
+        else if (attribute.default) res[key] = attribute.default;
+        return;
+      }
+
       if (attribute.type === 'json') {
         res[key] = JSON.stringify(entry[key]);
         return;


### PR DESCRIPTION
fixes #79 
If undefined, checks for default, if found, adds it - i.e. if mongoDB entry doesn't have a column value that it should have, add its default (if it exists). This problem is really strapi v3's problem, where it does not add DEFAULT properties to tables (specifically PostgreSQL)
Also, fixed an obvious typo.

### Why this approach
Since `Object.keys(entry).forEach(` already checks if a property is in the `model.attributes` (then returns if not),
I found it would work just as good the other way, to loop through the model's attributes and check if the entry contains it (trys to apply the default value if doesn't). 

### My Approach
I have only implemented the case where an `attribute.default` exists and the property is UNDEFINED (i.e. does not exist, **not** `= null`), the logic being that if it is '= null' it could have been set null for a reason, thus should only do this for undefined.
*Note: When I say 'undefined', I mean it is physically not defined in the object (i.e. 'b' is "undefined" in {a:1})*

I have limited testing capacity, so would appreciate some further testing on other people's systems for a wider range of applications. 


