### PR TITLE
Fix Typo 'model' misspelled as 'moel'

### DIFF
--- a/v3-mongodb-v3-sql/index.js
+++ b/v3-mongodb-v3-sql/index.js
@@ -226,7 +226,7 @@ async function run() {
 
             const targetAttribute = targetModel?.attributes?.[attribute.via];
 
-            const isOneWay = attribute.model && !attribute.via && attribute.moel !== '*';
+            const isOneWay = attribute.model && !attribute.via && attribute.model !== '*';
             const isOneToOne =
               attribute.model &&
               attribute.via &&


### PR DESCRIPTION
Fixed typo in code, where attribute was checking for 'moel' instead of 'model'
- closes #78