### PR TITLE
Fix issue with pascal case table names from v3

### DIFF
--- a/v3-sql-v4-sql/migrate/migrateComponents.js
+++ b/v3-sql-v4-sql/migrate/migrateComponents.js
@@ -95,7 +95,7 @@ async function migrateTables(tables) {
       }
     }
 
-    await migrate(table, table, (data) => {
+    await migrate(table, table.toLowerCase(), (data) => {
       const omitedData = omit(data, omitAttributes);
 
       return migrateItem(omitedData);
@@ -120,7 +120,7 @@ async function migrateTables(tables) {
 
     const tableIdColumn = singular(tableName);
 
-    await migrate(table, table, (item) => {
+    await migrate(table, table.toLowerCase(), (item) => {
       const itemNew = {
         ...item,
         entity_id: item[`${tableIdColumn}_id`],

--- a/v3-sql-v4-sql/migrate/migrateModels.js
+++ b/v3-sql-v4-sql/migrate/migrateModels.js
@@ -38,7 +38,7 @@ async function migrateModels(tables) {
         omitAttributes.push(key);
       }
     }
-    await migrate(modelDef.collectionName, modelDef.collectionName, (item) => {
+    await migrate(modelDef.collectionName, modelDef.collectionName.toLowerCase(), (item) => {
       if (modelDef.options.timestamps === false) {
         return migrateItem(item);
       } else {


### PR DESCRIPTION
We had two tables in our v3 database called "Pages" and "Websites" where the name started with a capital letter. 

These messages were appearing in the console, and the strapi4 tables were empty
```
DESTINATION TABLE Pages DOES NOT EXISTS
DESTINATION TABLE Websites DOES NOT EXISTS
```
This PR changes the destination table to the lowercase v4 format.  