### PR TITLE
Fix import issues with composite table names

### DIFF
--- a/v3-sql-v4-sql/migrate/helpers/relationHelpers.js
+++ b/v3-sql-v4-sql/migrate/helpers/relationHelpers.js
@@ -177,16 +177,19 @@ async function migrateRelations(tables, relations) {
     if (relation.type === 'oneToOne') {
       await migrateOneToOneRelation(relation);
     } else if (relation.type === 'manyToMany') {
+      const modelF = relation.modelF.replace("-", "_");
+      const attribute = snakeCase(relation.attribute);
       var sourceTable = v3RelationTables.find(
         (t) =>
-          t === `${relation.model}__${relation.attribute}` ||
-          t.startsWith(`${relation.model}_${relation.attribute}__${relation.modelF}`) ||
-          (t.startsWith(`${relation.modelF}`) &&
-            t.endsWith(`__${relation.model}_${relation.attribute}`))
+          t === `${relation.model}__${attribute}` ||
+          t.startsWith(`${relation.model}_${attribute}__${modelF}`) ||
+          (t.startsWith(`${modelF}`) && t.endsWith(`__${relation.model}_${attribute}`))
       );
 
       if (sourceTable) {
         await migrateManyToManyRelation(relation, sourceTable);
+      } else {
+        console.log(`WARNING - unable to idenitfy source table for relation: ` + relation.table);
       }
     }
   }


### PR DESCRIPTION
This PR fixes an issue that was preventing many-to-many  relationship data in `_links` tables from being migrated when the foreign key table was composed of more than one word.  

e.g. copying data from the v3 table `public_advisory_audits__protected_areas` to the v4 table `public_advisory_audits_protected_areas_links` was failing.

This was happening because `relation.modelF` contained hyphens and `relation.attribute` was camel case.  In both cases, the values needed to be converted to snake case.  