### PR TITLE
Specify implicit order for PostgreSQL to fix duplicate issue

### DIFF
--- a/v3-sql-v4-sql/migrate/helpers/migrate.js
+++ b/v3-sql-v4-sql/migrate/helpers/migrate.js
@@ -112,9 +112,18 @@ async function migrate(source, destination, itemMapper = undefined) {
 
   for (let page = 0; page * BATCH_SIZE < count; page++) {
     console.log(`${source} batch #${page + 1}`);
-    const items = await dbV3(resolveSourceTableName(source))
-      .limit(BATCH_SIZE)
-      .offset(page * BATCH_SIZE);
+    let items;
+
+    if (isPGSQL) {
+      items = await dbV3(resolveSourceTableName(source))
+        .limit(BATCH_SIZE)
+        .offset(page * BATCH_SIZE)
+        .orderBy('id', 'asc');
+    } else {
+      items = await dbV3(resolveSourceTableName(source))
+        .limit(BATCH_SIZE)
+        .offset(page * BATCH_SIZE);
+    }
 
     const withParsedJsonFields = items.map((item) => {
       if (jsonFields.length > 0) {


### PR DESCRIPTION
Related to internal TID2761

https://www.postgresql.org/docs/current/queries-limit.html

> "Thus, using different LIMIT/OFFSET values to select different subsets of a query result will give inconsistent results unless you enforce a predictable result ordering with ORDER BY. This is not a bug; it is an inherent consequence of the fact that SQL does not promise to deliver the results of a query in any particular order unless ORDER BY is used to constrain the order."