### PR TITLE
Fix fields undefined on certain v3 versions

### DIFF
--- a/v3-sql-v4-sql/migrate/helpers/adminHelpers.js
+++ b/v3-sql-v4-sql/migrate/helpers/adminHelpers.js
@@ -47,11 +47,11 @@ async function migrateAdminPermissions() {
     const items = await dbV3(resolveSourceTableName(source))
       .limit(BATCH_SIZE)
       .offset(page * BATCH_SIZE);
-    const migratedItems = migrateItems(items, ({ role, ...item }) => ({
+    const migratedItems = migrateItems(items, ({ role, fields, properties, ...item }) => ({
       ...item,
       action: migrateUids(item.action),
       subject: migrateSubject(item.subject),
-      properties: migrateProperties(item.properties),
+      properties: migrateProperties(properties ?? { fields: JSON.parse(fields) }),
       conditions: isPGSQL ? JSON.stringify(item.conditions) : item.conditions,
     }));
     const roleLinks = items.map((item) => ({


### PR DESCRIPTION
Uses a community patch (thank you @abanchev) from: https://github.com/strapi/migration-scripts/issues/83#issuecomment-1520195568

fixes #83

Certain v3 versions don't have the fields in their database if they upgraded without starting the upgraded v3 application