### PR TITLE
fix many to many relation migrate error when fields in same collection

### DIFF
--- a/v3-mongodb-v3-sql/index.js
+++ b/v3-mongodb-v3-sql/index.js
@@ -307,7 +307,7 @@ async function run() {
                 let otherFk = `${singular(attribute.collection)}_id`;
 
                 if (otherFk === fk) {
-                  fk = `${singular(attribute.via)}_id`;
+                  otherFk = `${singular(targetAttribute.via)}_id`;
                 }
 
                 const rows = entry[key].map((id) => {


### PR DESCRIPTION
eg. A.xs -- A.ys
the 3.x sql db 's structure is id, a_id, x_id,
old logic will insert a_id, y_id.