### PR TITLE
Fix column name where relation has same name as the component

### DIFF
--- a/v3-sql-v4-sql/migrate/helpers/relationHelpers.js
+++ b/v3-sql-v4-sql/migrate/helpers/relationHelpers.js
@@ -88,7 +88,7 @@ function oneToOneRelationMapper(relation, item) {
       : makeRelationModelId(relation.modelF);
     return {
       [makeRelationModelId(relation.entityName, { isComponent: relation.isComponent })]: id,
-      [makeRelationModelId(relation.modelF)]: idF,
+      [keyF]: idF,
     };
   }
   return undefined;


### PR DESCRIPTION
I think the keyF variable is set correctly but it is not used in the actual column names. It's an unused variable, so this seems maybe something went wrong in merging this code into master or something?