### PR TITLE
Filter information_schema.tables result by the relevant table_schema 

### DIFF
--- a/v3-sql-v4-sql/migrate/index.js
+++ b/v3-sql-v4-sql/migrate/index.js
@@ -53,7 +53,11 @@ async function migrate() {
   }
 
   if (isMYSQL) {
-    tables = (await dbV3('information_schema.tables').select('table_name')).map((row) => {
+    tables = (
+      await dbV3('information_schema.tables')
+        .select('table_name')
+        .where('table_schema', process.env.DATABASE_V3_DATABASE)
+    ).map((row) => {
       return row.table_name || row.TABLE_NAME;
     });
   }

--- a/v3-sql-v4-sql/migrate/migrateComponents.js
+++ b/v3-sql-v4-sql/migrate/migrateComponents.js
@@ -52,7 +52,10 @@ async function migrateTables(tables) {
 
   if (isSQLITE) {
     componentRelationsTables = (
-      await dbV3('sqlite_master').select('name').where('name', 'like', '%_components')
+      await dbV3('sqlite_master')
+        .select('name')
+        .where('name', 'like', '%_components')
+        .where('table_schema', process.env.DATABASE_V3_DATABASE)
     )
       .map((row) => row.name)
       .filter((item) => !componentsToMigrate.includes(item));
@@ -87,7 +90,7 @@ async function migrateTables(tables) {
             value,
             collectionName: componentDefinitionObject.collectionName,
             uid: componentDefinitionObject.uid,
-            isComponent: true
+            isComponent: true,
           },
           relations
         );


### PR DESCRIPTION
In MySQL it is necessary to filter results of the `infromation_schema.tables` SELECT query by the `table_schema` to prevent knex from attempting to migrate table names from unrelated databases within the same MySQL instance. 

This fix targets Internal-TID: 5291