### PR TITLE
Convert DATABASE_V3_SSL / DATABASE_V4_SSL to boolean

### DIFF
--- a/v3-sql-v4-sql/config/database.js
+++ b/v3-sql-v4-sql/config/database.js
@@ -27,7 +27,7 @@ if (process.env.DATABASE_CLIENT === 'pg') {
       user: process.env.DATABASE_V3_USER,
       password: process.env.DATABASE_V3_PASSWORD,
       database: process.env.DATABASE_V3_DATABASE,
-      ssl: process.env.DATABASE_V3_SSL,
+      ssl: process.env.DATABASE_V3_SSL === 'true',
     },
   };
 
@@ -39,7 +39,7 @@ if (process.env.DATABASE_CLIENT === 'pg') {
       user: process.env.DATABASE_V4_USER,
       password: process.env.DATABASE_V4_PASSWORD,
       database: process.env.DATABASE_V4_DATABASE,
-      ssl: process.env.DATABASE_V4_SSL,
+      ssl: process.env.DATABASE_V4_SSL === 'true',
     },
   };
 }


### PR DESCRIPTION
Setting `DATABASE_V3_SSL` / `DATABASE_V4_SSL` to `false` in .env doesn't actually work because the values are passed as strings to `pg`, which interprets them as `true`.